### PR TITLE
rmprotobufwrapper: use xiqnet's implementation of protobufToByteArray

### DIFF
--- a/rmprotobufwrapper.cpp
+++ b/rmprotobufwrapper.cpp
@@ -18,8 +18,3 @@ std::shared_ptr<google::protobuf::Message> RMProtobufWrapper::byteArrayToProtobu
   }
   return proto;
 }
-
-QByteArray RMProtobufWrapper::protobufToByteArray(const google::protobuf::Message &t_protobufMessage)
-{
-  return QByteArray(t_protobufMessage.SerializeAsString().c_str(), t_protobufMessage.ByteSizeLong());
-}

--- a/rmprotobufwrapper.h
+++ b/rmprotobufwrapper.h
@@ -6,11 +6,9 @@
 class RMProtobufWrapper : public XiQNetWrapper
 {
 public:
-  RMProtobufWrapper();
+    RMProtobufWrapper();
 
-  std::shared_ptr<google::protobuf::Message> byteArrayToProtobuf(QByteArray t_data) override;
-
-  QByteArray protobufToByteArray(const google::protobuf::Message &t_protobufMessage) override;
+    std::shared_ptr<google::protobuf::Message> byteArrayToProtobuf(QByteArray t_data) override;
 };
 
 #endif // PROTOBUFWRAPPER_H


### PR DESCRIPTION
Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>