### PR TITLE
Get rid of Qt Gui dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ include(FeatureSummary)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
-find_package(Qt5 COMPONENTS Core Gui Network CONFIG REQUIRED)
+find_package(Qt5 COMPONENTS Core Network CONFIG REQUIRED)
 find_package(xiqnet REQUIRED)
 find_package(zeraprotobuf REQUIRED)
 find_package(SCPI REQUIRED)
@@ -45,7 +45,6 @@ add_library(resman-lib STATIC
 target_link_libraries(resman-lib
     PUBLIC
     Qt5::Core
-    Qt5::Gui
     Qt5::Network
     VeinMeta::xiqnet
     VeinMeta::zeraprotobuf

--- a/resman-libConfig.cmake.in
+++ b/resman-libConfig.cmake.in
@@ -1,6 +1,6 @@
 include(CMakeFindDependencyMacro)
 
-find_dependency(Qt5 COMPONENTS Core Gui Network CONFIG REQUIRED)
+find_dependency(Qt5 COMPONENTS Core Network CONFIG REQUIRED)
 find_dependency(xiqnet REQUIRED)
 find_dependency(zeraprotobuf REQUIRED)
 find_dependency(SCPI REQUIRED)

--- a/scpi/resman_scpiinterface.cpp
+++ b/scpi/resman_scpiinterface.cpp
@@ -30,11 +30,6 @@ namespace SCPI
     m_scpiInstance->genSCPICmd(aTMP,m_catalogType);
   }
 
-  QStandardItemModel *SCPIInterface::getModel() const
-  {
-    return m_scpiInstance->getSCPIModel();
-  }
-
   QString SCPIInterface::listTypes() const
   {
     QString retVal = getTypedCatalogHash().uniqueKeys().join(';');

--- a/scpi/resman_scpiinterface.h
+++ b/scpi/resman_scpiinterface.h
@@ -8,10 +8,6 @@
 #include <scpi.h>
 #include "resman_delegate.h"
 
-QT_BEGIN_NAMESPACE
-class QStandardItemModel;
-QT_END_NAMESPACE
-
 namespace ResourceServer
 {
   class ClientMultiton;
@@ -78,11 +74,6 @@ namespace SCPI
     Q_OBJECT
   public:
     explicit SCPIInterface(ResourceManager *t_resourceManager, QObject *t_parent=0);
-
-    /**
-      @brief For debugging, returns the cSCPI::model
-      */
-    QStandardItemModel* getModel() const;
 
     /**
       @brief Lists types which have a Catalog command


### PR DESCRIPTION
Qt Gui ruins unittests in oe

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>