### PR TITLE
Remove Delegate's default ctor - cSCPIObject's default ctor will go

### DIFF
--- a/scpi/resman_delegate.cpp
+++ b/scpi/resman_delegate.cpp
@@ -2,10 +2,6 @@
 
 namespace SCPI
 {
-  Delegate::Delegate() : cSCPIObject()
-  {
-  }
-
   Delegate::Delegate(const QString &t_name, quint8 t_type) : cSCPIObject(t_name, t_type)
   {
   }


### PR DESCRIPTION
Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>