### PR TITLE
resman_scpiinterface: Follow zera-scpi/cSCPI changes

### DIFF
--- a/scpi/resman_scpiinterface.h
+++ b/scpi/resman_scpiinterface.h
@@ -145,7 +145,7 @@ private:
     /**
       @brief SCPI library interaction is held here
       */
-    cSCPI* m_scpiInstance = new cSCPI("Resourcemanager");
+    cSCPI* m_scpiInstance = new cSCPI();
 
     /**
      * @brief pointer to the resource manager


### PR DESCRIPTION
* cSCPI no longer needs scpi-interface name (it was used only for DEVICE tag)
* Remove DEVICE tag from xml created using exportSCPIModelXML. Perhaps it was not needed there, it was done to make zera-scpi happy